### PR TITLE
fix #590

### DIFF
--- a/client/app/scripts/services/models.js
+++ b/client/app/scripts/services/models.js
@@ -13,7 +13,7 @@ angular.module("ShadowWolf")
     var updateMethod = getModel(objectName)._get().update;
     return function(id, postData, success, error) {
       var idObject = {};
-      idObject[objectName + 'Id'] = id;
+      idObject[objectName + 'IdOr' + (objectName == 'person' ? 'Login' : 'ProjectNumber') ] = id;
       return updateMethod(idObject, postData, success, error);
     };
   };


### PR DESCRIPTION
models service was miscalling the params name {person,project}Id,
forgetting the Or{login,ProjectNumber} suffix that as added recently